### PR TITLE
fix: Use encode encodeURIComponent instead of encodeURI

### DIFF
--- a/src/templates/core/OpenAPI.hbs
+++ b/src/templates/core/OpenAPI.hbs
@@ -26,5 +26,5 @@ export const OpenAPI: OpenAPIConfig = {
 	USERNAME: undefined,
 	PASSWORD: undefined,
 	HEADERS: undefined,
-	ENCODE_PATH: undefined,
+	ENCODE_PATH: encodeURIComponent,
 };


### PR DESCRIPTION
https://github.com/ferdikoomen/openapi-typescript-codegen/wiki/OpenAPI-object#openapiencode_path 