### PR TITLE
fix: Remove condition for aborted signal

### DIFF
--- a/src/templates/core/fetch/request.hbs
+++ b/src/templates/core/fetch/request.hbs
@@ -88,11 +88,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 				resolve(result.body);
 			}
 		} catch (error) {
-			if (error instanceof Error && error.name === 'AbortError') {
-				return
-			} else {
-				reject(error)
-			}
+			reject(error);
 		}
 	});
 };

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -560,11 +560,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
                 resolve(result.body);
             }
         } catch (error) {
-            if (error instanceof Error && error.name === 'AbortError') {
-                return
-            } else {
-                reject(error)
-            }
+            reject(error);
         }
     });
 };
@@ -3687,11 +3683,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
                 resolve(result.body);
             }
         } catch (error) {
-            if (error instanceof Error && error.name === 'AbortError') {
-                return
-            } else {
-                reject(error)
-            }
+            reject(error);
         }
     });
 };


### PR DESCRIPTION
I want to fix these sentry reports:
<img width="1165" height="617" alt="image" src="https://github.com/user-attachments/assets/786efe37-5438-47ec-a2ee-006797d7ea00" />

After I did this change in some api requests I think it improved but we have many other api requests... 
<img width="1003" height="290" alt="image" src="https://github.com/user-attachments/assets/20c3dc53-d74c-4bbd-9eed-2ea7ef2987b3" />

So I thought about going to the api repository and noticed we were avoiding throwing an error in case of aborted signal... But that is creating this case where it passes as a false positive, and then we throw errors because data was not returned... 

I think it is better to throw the errors and handle abort signals as "don't show anything in the UI" instead. Like we already do in our handleException 
<img width="469" height="104" alt="image" src="https://github.com/user-attachments/assets/76d326d1-2a1c-4f63-9dbf-eee5a2bef640" />
The only consequence from this is that the aborts will show up as error messages in the console. But I think that is good. 
I accept new ideas 😄 