### PR TITLE
security: Delay dependabot updates [TAROT-3707]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,24 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: "daily"
-  ignore:
-    - dependency-name: "@types/node-fetch"
-    - dependency-name: "node-fetch"
-    - dependency-name: "camelcase"
-    - dependency-name: "@angular-devkit/build-angular"
-    - dependency-name: "@angular/animations"
-    - dependency-name: "@angular/cli"
-    - dependency-name: "@angular/common"
-    - dependency-name: "@angular/compiler"
-    - dependency-name: "@angular/compiler-cli"
-    - dependency-name: "@angular/core"
-    - dependency-name: "@angular/forms"
-    - dependency-name: "@angular/platform-browser"
-    - dependency-name: "@angular/platform-browser-dynamic"
-    - dependency-name: "@angular/router"
-    - dependency-name: "typescript"
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "@types/node-fetch"
+      - dependency-name: "node-fetch"
+      - dependency-name: "camelcase"
+      - dependency-name: "@angular-devkit/build-angular"
+      - dependency-name: "@angular/animations"
+      - dependency-name: "@angular/cli"
+      - dependency-name: "@angular/common"
+      - dependency-name: "@angular/compiler"
+      - dependency-name: "@angular/compiler-cli"
+      - dependency-name: "@angular/core"
+      - dependency-name: "@angular/forms"
+      - dependency-name: "@angular/platform-browser"
+      - dependency-name: "@angular/platform-browser-dynamic"
+      - dependency-name: "@angular/router"
+      - dependency-name: "typescript"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
7 days should be enough when most malicious packages are patched within 24 hours.